### PR TITLE
Update building_rest_apis.md

### DIFF
--- a/full/recipes/building_rest_apis.md
+++ b/full/recipes/building_rest_apis.md
@@ -110,16 +110,9 @@ The default route for our `user.cfc` handler is `/api/user`, but what if we want
 Let's add the following new routes to our `/config/routes.cfm` file BEFORE the default route.
 
 ```js
-// map base route to list users
-addRoute(
-  pattern = 'api/user',
-  handler = 'api.user',
-  action = 'index'
-);
-
 // Map route to specific user.  Different verbs call different actions!
 addRoute(
-  pattern = 'api/user/:userID?',
+  pattern = 'api/user/:userID',
   handler = 'api.user',
   action = {
     GET = 'view',
@@ -127,6 +120,13 @@ addRoute(
     PUT = 'save',
     DELETE = 'remove'
   });
+
+// map base route to list users
+addRoute(
+  pattern = 'api/user',
+  handler = 'api.user',
+  action = 'index'
+);
 ```
 
 You can see if that if action is a string, all HTTP verbs will be mapped there, however a `struct` can also be provided that maps different verbs to different actions. This gives you exact control over how the requests are routed.


### PR DESCRIPTION
The documented way did not work for me. Using that documented way, when I accessed GET /api/user  the index fn ran but when I accessed GET /api/user/4   the index fn ran not the view fn.  I got it to work by reversing the order of the routes so the more narrow route was listed first and removing the ? in the pattern. If I didn't remove the ? in the pattern but still listed that first, both /api/user  and /api/user/3  ran the view fn.