### PR TITLE
Change default to defaultValue in flash.get example

### DIFF
--- a/full/flash_ram/using_flash_ram.md
+++ b/full/flash_ram/using_flash_ram.md
@@ -237,6 +237,6 @@ function show(event){
 </cfif>
 
 // User/show.cfm using defaults
-<div class="notice">#flash.get(name="notice",default="")</div>
+<div class="notice">#flash.get(name="notice",defaultValue="")</div>
 ```
 


### PR DESCRIPTION
<div class="notice">#flash.get(name="notice",default="")</div> 
should be
<div class="notice">#flash.get(name="notice",defaultValue="")</div>