### PR TITLE
Correct link to image

### DIFF
--- a/hmvc/modules/module-service/module-lifecycle.md
+++ b/hmvc/modules/module-service/module-lifecycle.md
@@ -1,6 +1,6 @@
 # Module Lifecycle
 
-![](https://github.com/ortus/coldbox-platform-documentation/tree/24d3f3d16693b36ca41bf5ce0329c6ff33316ef0/images/ModulesLifecycle.jpg)
+![](https://github.com/ortus-docs/coldbox-docs/raw/master/full/images/ModulesLifecycle.jpg)
 
 However, before we start reviewing the module service methods let's review how modules get loaded in a ColdBox application. Below is a simple bullet point of what happens in your application when it starts up:
 


### PR DESCRIPTION
Current image path is broken; it's pointing to the old repository name.

I updated it to point to the image on the master branch of the current repository. 

I left the path as absolute, because I'm not sure how GitBooks handles the relative paths. If you'd prefer that I move the images to the `.gitbook/assets` directory and update the paths to be relative, just let me know.