### PR TITLE
Fixed links to wirebox docs.

### DIFF
--- a/the-basics/models/object-scopes.md
+++ b/the-basics/models/object-scopes.md
@@ -33,6 +33,6 @@ component name="MyService" scope="session"{}
 
 > **Hint** Pease note that using annotations is optional, you can configure every object in our configuration binder as well.
 
-* Persistence DSL: [http://wirebox.ortusbooks.com/content/mapping\_dsl/persistence\_dsl.html](http://wirebox.ortusbooks.com/content/mapping_dsl/persistence_dsl.html)
-* Object Persistence & Thread Safety: [http://wirebox.ortusbooks.com/content/object\_persistence\_&\_thread\_safety/index.html](http://wirebox.ortusbooks.com/content/object_persistence_&_thread_safety/index.html)
+* Persistence DSL: [http://wirebox.ortusbooks.com/configuration/mapping-dsl/persistence-dsl](http://wirebox.ortusbooks.com/configuration/mapping-dsl/persistence-dsl)
+* Object Persistence & Thread Safety: [http://wirebox.ortusbooks.com/advanced-topics/object-persistence-and-thread-safety](http://wirebox.ortusbooks.com/advanced-topics/object-persistence-and-thread-safety)
 

--- a/the-basics/models/wirebox-binder.md
+++ b/the-basics/models/wirebox-binder.md
@@ -47,7 +47,7 @@ component extends="coldbox.system.ioc.config.Binder"{
 }
 ```
 
-Please refer to the full Binder documentation: \([http://wirebox.ortusbooks.com/content/configuring\_wirebox/index.html](http://wirebox.ortusbooks.com/content/configuring_wirebox/index.html)\) for further inspection.
+Please refer to the full Binder documentation: \([http://wirebox.ortusbooks.com/configuration/configuring-wirebox/](http://wirebox.ortusbooks.com/configuration/configuring-wirebox/)\) for further inspection.
 
 ## Mappings
 


### PR DESCRIPTION
I found a few links that seem to be outdated. Replaced them with working links found through Wirebox docs search.