### PR TITLE
Update logbox.md

### DIFF
--- a/getting-started/configuration/coldbox.cfc/configuration-directives/logbox.md
+++ b/getting-started/configuration/coldbox.cfc/configuration-directives/logbox.md
@@ -5,8 +5,8 @@ The logBox structure is based on the LogBox declaration DSL, see the [LogBox Doc
 ```javascript
 //LogBox DSL
 logBox = {
-    // The configuration file to use for operation, instead of using this structure
-    configFile = "config/LogBox.cfc",
+    // The configuration file without fileextension to use for operation, instead of using this structure
+    configFile = "config/LogBox", 
     // Appenders
     appenders = {
         appenderName = {


### PR DESCRIPTION
To use an external Logbox.cfc Config file via configFile config key only works without the cfc extension