### PR TITLE
Point API docs url to new API documentation search

### DIFF
--- a/the-basics/event-handlers/viewlets-reusable-events.md
+++ b/the-basics/event-handlers/viewlets-reusable-events.md
@@ -18,7 +18,7 @@ What in the world is this? Well, imagine a portal, in which each section of the 
 This code just renders out the results of a `runEvent()` method call. Please note that you can pass in arguments to the event using the `eventArguments` argument.  This makes the event act like a method call with arguments to ti.  Remember that all events you call via `runEvent()` will share the same RC/PRC.
 
 {% hint style="info" %}
-I would suggest you look at [the API docs](http://apidocs.ortussolutions.com/coldbox/current) to discover all arguments to the `runEvent()` method call.
+I would suggest you look at [the API docs](https://apidocs.coldbox.org/) to discover all arguments to the `runEvent()` method call.
 {% endhint %}
 
 ### **Event Code**


### PR DESCRIPTION
In my mind, [these newer API docs](https://apidocs.coldbox.org/) for Coldbox are much improved, and should therefore be utilized as much as possible!

Which means we should probably do a `sed -i -e 's/http:\/\/apidocs.ortussolutions.com\/coldbox\/current/https:\/\/apidocs.coldbox.org/' *.md` to update them all at once. I'm frankly too lazy for that, so here's one. :)