### PR TITLE
"Solo Style" Datasource docs not compatible with CB 5

### DIFF
--- a/the-basics/models/coding-solo-style/datasource.md
+++ b/the-basics/models/coding-solo-style/datasource.md
@@ -1,12 +1,28 @@
 # Datasource
 
-Make sure you register a datasource in your ColdFusion administrator, we called ours `contacts` and then register it in your ColdBox configuration so ColdBox can build datasource structs for us. This is totally optional, but we do it to showcase more injections:
-
-`config/ColdBox.cfc`
+To use a datasource in ColdBox 5, add the Lucee datasource struct to your `config/Coldbox.cfc` configuration file settings:
 
 ```javascript
-datasources = {
-    contacts = {name="contacts", dbtype="mySQL"}
-};
+settings = {
+    myDSN : {
+        class: "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+        connectionString: "jdbc:sqlserver://HOST",
+        connectionLimit: 5,
+        username: "me",
+        password: "plaintext_password"
+    }
+}
 ```
 
+You can even use Coldbox's native `getSystemSetting()` function to pull database secrets from your Java system properties or environment variables:
+
+```javascript
+settings = {
+    myDSN : {
+        class : "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+        connectionString : "jdbc:sqlserver://#getSystemSetting("DB_CONNECTIONSTRING")#",
+        username : getSystemSetting("DB_USER"),
+        password : getSystemSetting("DB_PASSWORD")
+    }
+}
+```


### PR DESCRIPTION
This was out of date / not ColdBox 5 compatible. I tried to update this to be compatible with ColdBox 5. Note that this will also require an update to the `contactDAO.cfc` docs in that same section: https://coldbox.ortusbooks.com/the-basics/models/coding-solo-style/contactdao.cfc