### PR TITLE
Remove last mention of afterInstanceAutowire intercept point

### DIFF
--- a/digging-deeper/interceptors/interceptor-registration.md
+++ b/digging-deeper/interceptors/interceptor-registration.md
@@ -34,11 +34,11 @@ controller.getInterceptorService()
 controller.getInterceptorService()
     .registerInterceptor( interceptorObject=this, customPoints="onError,onLogin" );
 
-// Register yourself to listen to ONLY the afterInstanceAutowire event
+// Register yourself to listen to the onException event ONLY
 controller.getInterceptorService()
     .registerInterceptionPoint( 
         interceptorKey="MyService", 
-        state="afterInstanceAutowire", 
+        state="onException", 
         oInterceptor=this
      );
 ```


### PR DESCRIPTION
Since I saw that `afterInstanceAutowire` has been removed in 5.6, I went and looked through the docs and sure enough - `afterInstanceAutowire` was mentioned in the Interceptor Registration doc.

I _could_ update this to simply add a warning instead - e.g. "afterInstanceAutowire has been removed in Coldbox 5.6+", but I think this makes more sense.