### PR TITLE
Fix missing ? in htaccess rewrite rule

### DIFF
--- a/the-basics/routing/requirements/rewrite-rules.md
+++ b/the-basics/routing/requirements/rewrite-rules.md
@@ -18,7 +18,7 @@ RewriteRule ^(.*)$ - [NC,L]
 RewriteRule ^$ index.cfm [QSA,NS]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^(.*)$ index.cfm%{REQUEST_URI} [QSA,L,NS]
+RewriteRule ^(.*)$ index.cfm?%{REQUEST_URI} [QSA,L,NS]
 ```
 
 ## nginx


### PR DESCRIPTION
Without the ?, a URN foo would be rewritten to index.cfmfoo instead of index.cfm?foo, resulting in a 404 by Apache.