### PR TITLE
Fix Wirebox documentation URL in Coldbox docs

### DIFF
--- a/getting-started/configuration/coldbox.cfc/configuration-directives/wirebox.md
+++ b/getting-started/configuration/coldbox.cfc/configuration-directives/wirebox.md
@@ -1,6 +1,6 @@
 # WireBox
 
-This configuration structure is used to configure the [WireBox](http://wiki.coldbox.org/wiki/WireBox.cfm) dependency injection framework embedded in ColdBox.
+This configuration structure is used to configure the [WireBox](https://wirebox.ortusbooks.com) dependency injection framework embedded in ColdBox.
 
 ```javascript
 // wirebox integration


### PR DESCRIPTION
Hey Luis, the url to Wirebox is busted! Found and fixed.