### PR TITLE
Add deprecation notice in module autoReload code sample

### DIFF
--- a/hmvc/modules/parent-configuration.md
+++ b/hmvc/modules/parent-configuration.md
@@ -5,6 +5,7 @@ There are a few parent application settings when dealing with modules. In your `
 ```text
 modules = {
     // reload and unload modules in every request
+    // DEPRECATED in coldbox 5
     autoReload = false,
     // An array or list of the module names that will load ONLY
     include = [],


### PR DESCRIPTION
We should either a) not have this `autoReload` mentioned at all, or b) mention that it is deprecated in coldbox 5.