### PR TITLE
Document renderResults and withExceptionHandling arguments

### DIFF
--- a/testing/testing-coldbox-applications/integration-testing/the-execute-method.md
+++ b/testing/testing-coldbox-applications/integration-testing/the-execute-method.md
@@ -10,4 +10,5 @@ The `execute()` method is your way of making requests in to your ColdBox applica
 | private | boolean | `false` | `false` | If `true`, sets the event execution as private. |
 | prePostExempt | boolean | `false` | `false` | If `true`, skips the pre- and post- interceptors. e.g., `preEvent`, `postHandler`, etc. |
 | eventArguments | struct | `false` | `{}` | A collection of arguments to passthrough to the calling event handler method. |
-
+| renderResults | struct | `false` | `false` | If true, then it will try to do the normal rendering procedures and store the rendered content in the RC as `cbox_rendered_content`. |
+| withExceptionHandling  | boolean | `false` | `false` |  If true, then ColdBox will process any errors through the exception handling framework instead of just throwing the error. |


### PR DESCRIPTION
Document these two missing arguments for Coldbox's `BaseTestCase` for integration testing.