### PR TITLE
Fixing a typo in the .toRedirect() example

### DIFF
--- a/the-basics/routing/README.md
+++ b/the-basics/routing/README.md
@@ -41,7 +41,7 @@ function configure(){
 
     // Redirects
     route( "/old/book" )
-        .redirect( "/mybook" );
+        .toRedirect( "/mybook" );
 
     // Responses
     route( "/echo" ).toResponse( (event,rc,prc) => {


### PR DESCRIPTION
.redirect() doesn't exist. changed that example to use .toRedirect() instead.