### PR TITLE
Bug Report files moved

### DIFF
--- a/intro/release-history/upgrading-to-coldbox-5.md
+++ b/intro/release-history/upgrading-to-coldbox-5.md
@@ -18,3 +18,6 @@ The following settings have been changed and altering behavior:
 * `coldbox.onInvalidEvent` has been REMOVED in preference to `coldbox.invalidEventHandler`
 * `coldbox.jsonPayloadToRC` is now defaulted to **true**
 
+## System Path Changes
+
+* Default Bug Report Files are now located in `/coldbox/system/exceptions/`. Previously `/coldbox/system/includes/`


### PR DESCRIPTION
When upgrading from ColdBox 5.x, the default CustomErrorTemplate setting in ColdBox.cfc for development env points to `/coldbox/system/includes/` for BugReport.cfm and BugReport-Public.cfm.