### PR TITLE
Fixing typos in the comments and missing cfoutput tags

### DIFF
--- a/the-basics/layouts-and-views/layouts/nested-layouts.md
+++ b/the-basics/layouts-and-views/layouts/nested-layouts.md
@@ -11,7 +11,7 @@ So if I wanted to wrap my basic layout in a PDF wrapper layout \(`pdf.cfm`\) I c
 ```javascript
 <cfdocument pagetype="letter" format="pdf">
 
-    <---  Header --->
+    <!---  Header --->
     <cfdocumentitem type="header">
     <cfoutput>
     <div>
@@ -20,7 +20,7 @@ So if I wanted to wrap my basic layout in a PDF wrapper layout \(`pdf.cfm`\) I c
     </cfoutput>
     </cfdocumentitem>
 
-    <---  Footer --->
+    <!---  Footer --->
     <cfdocumentitem type="footer">
     <cfoutput>
     <div>
@@ -29,8 +29,10 @@ So if I wanted to wrap my basic layout in a PDF wrapper layout \(`pdf.cfm`\) I c
     </cfoutput>
     </cfdocumentitem>
 
-    <---  Main Content via nested layout --->
+    <!---  Main Content via nested layout --->
+    <cfoutput>
     #renderLayout(layout="basic")#
+    </cfoutput>
 
 </cfdocument>
 ```


### PR DESCRIPTION
The comments were missing the exclamation points. Also the layout wasn't rendering properly due to a missing cfoutput tag, that's now fixed.