### PR TITLE
Update Release History page to bulleted list

### DIFF
--- a/intro/release-history/README.md
+++ b/intro/release-history/README.md
@@ -1,18 +1,10 @@
 # Release History
 
-In this section you will find the release notes for each version we release under this major version.  If you are looking for the release notes of previous major versions use the version switcher at the top left of this documentation book.  Here is a breakdown of our major version releases.
+In this section you will find the release notes for each version we release under this major version. If you are looking for the release notes of previous major versions use the version switcher at the top left of this documentation book.  Here is a breakdown of our major version releases.
 
-## Version 6.0 - August 2020
-
-## Version 5.0 - July 2018
-
-## Version 4.0 - January 2015
-
-## Version 3.0 - March 2011
-
-## Version 2.0 - April 2007
-
-## Version 1.0 - June 2006
-
-
-
+* [Version 6.0 - August 2020](whats-new-with-6.0.0.md)
+* [Version 5.0 - July 2018](https://coldbox.ortusbooks.com/v/v5.x/intro/introduction/whats-new-with-5.0.0)
+* [Version 4.0 - January 2015](https://coldbox.ortusbooks.com/v/v4.x/intro/introduction/whats-new-with-4.0.0)
+* Version 3.0 - March 2011
+* Version 2.0 - April 2007
+* Version 1.0 - June 2006


### PR DESCRIPTION
I got really confused by lots of section headings with no content for each section. Instead, I changed this to a bulleted list and linked the top 3 items (CB6, CB5, and CB4) to the docs we *do* have for them. IMO this is a definite improvement in user "understandability". :)