### PR TITLE
Replaced setNextEvent() with relocate()

### DIFF
--- a/digging-deeper/recipes/building-rest-apis.md
+++ b/digging-deeper/recipes/building-rest-apis.md
@@ -554,7 +554,7 @@ component {
         flash.put("exceptionURL", event.getCurrentRoutedURL() );
 
         // Relocate to fail page
-        setNextEvent("main.fail");
+        relocate("main.fail");
     }
 }
 ```


### PR DESCRIPTION
SetNextEvent() was removed in Coldbox 6