### PR TITLE
Update deprecated `announceInterception()` in CB6 docs

### DIFF
--- a/digging-deeper/coldbox-proxy/the-base-proxy-object.md
+++ b/digging-deeper/coldbox-proxy/the-base-proxy-object.md
@@ -4,7 +4,7 @@ Here are some common methods of our ColdBox proxy object. However, we encourage 
 
 | Method | Description |
 | :--- | :--- |
-| announceInterception\(state, data\) | Processes a remote interception. |
+| announce\(state, data\) | Processes a remote interception. |
 | getCacheBox\(\) | Get a reference to [CacheBox](http://wiki.coldbox.org/wiki/CacheBox.cfm) |
 | getCache\(cacheName='default'\) | Get a reference to a named cache provider |
 | getController\(\) | Returns the ColdBox controller instance |

--- a/digging-deeper/interceptors/README.md
+++ b/digging-deeper/interceptors/README.md
@@ -16,7 +16,7 @@ The way that interceptors are used is usually referred to as event-driven progra
 
 // Announce inside a function
 if( userCreated ){
-    announceInterception( 'onUserCreate', { user = prc.oUser } );
+    announce( 'onUserCreate', { user = prc.oUser } );
 }
 ```
 

--- a/digging-deeper/interceptors/interceptor-asynchronicity/README.md
+++ b/digging-deeper/interceptors/interceptor-asynchronicity/README.md
@@ -3,7 +3,7 @@
 In honor of one of my favorite bands and album, [The Police](http://en.wikipedia.org/wiki/Synchronicity_%28The_Police_album%29) - [Synchronicity](https://www.youtube.com/watch?v=Si5CSpUCDGY), we have some asynchronous capabilities in ColdBox Interceptors. These features are thanks to the sponsorship of \[Guardly\] Inc, Alert, Connect, Stay Safe. So please make sure to check them out and thank them for sponsoring this great feature set. The core interceptor service and announcement methods have some arguments that can turn asynchronicity on or off and can return a structure of threading data.
 
 ```javascript
-any announceInterception(state, data, async, asyncAll, asyncAllJoin, asyncJoinTimeout, asyncPriority);
+any announce(state, data, async, asyncAll, asyncAllJoin, asyncJoinTimeout, asyncPriority);
 ```
 
 The asynchronous arguments are listed in the table below:
@@ -16,10 +16,10 @@ The asynchronous arguments are listed in the table below:
 | asyncPriority | string : _low,normal,high_ | false | normal | The thread priority that will be sent to each _cfthread_ call that is made by the system. |
 | asyncJoinTimeout | numeric | false | 0 | This argument is only used when using the _asyncAll_ and _asyncAllJoin=true_ arguments. This argument is the number of milliseconds the calling thread should wait for all the threaded CFC listeners to execute. By default it waits until all threads finalize. |
 
-All asynchronous calls will return a structure of thread information back to you when using the `announceInterception()` method or directly in the interceptor service, the `processState()` method. The structure contains information about all the threads that where created during the call and their respective information like: status, data, errors, monitoring, etc.
+All asynchronous calls will return a structure of thread information back to you when using the `announce()` method or directly in the interceptor service, the `processState()` method. The structure contains information about all the threads that where created during the call and their respective information like: status, data, errors, monitoring, etc.
 
 ```javascript
-threadData = announceInterception(
+threadData = announce(
     state           = "onLogin", 
     data            = { user=user }, 
     asyncAll        = true

--- a/digging-deeper/interceptors/interceptor-asynchronicity/async-announcements.md
+++ b/digging-deeper/interceptors/interceptor-asynchronicity/async-announcements.md
@@ -3,7 +3,7 @@
 The first case involves where you want to completely detach an interception call into the background. You will accomplish this by using the `async=true` argument. This will then detach the execution of the interception into a separate thread and return to you a structure containing information about the thread it created for you. This is a great way to send work jobs, emails, processing and more to the background instead of having the calling thread wait for execution.
 
 ```javascript
-threadData = announceInterception(
+threadData = announce(
     state           = "onPageCreate", 
     data            = { page= local.page }, 
     asyncAll        = true
@@ -17,7 +17,7 @@ You can also combine this call with the following arguments:
 * `asyncPriority` : The priority level of the detached thread. By default it uses `normal` priority level.
 
 ```javascript
-threadData = announceInterception(
+threadData = announce(
     state           = "onPageCreate", 
     data            = { page= local.page }, 
     asyncAll        = true,


### PR DESCRIPTION
The method name was changed to `announce()` (which I LOVE), so we should make sure the docs prefer that naming going forward. :+1: