### PR TITLE
Update docs for deprecated renderExternalView method

### DIFF
--- a/the-basics/layouts-and-views/views/rendering-external-views.md
+++ b/the-basics/layouts-and-views/views/rendering-external-views.md
@@ -1,8 +1,11 @@
 # Rendering External Views
 
-So what if I want to render a view outside of my application without using the setting explained above? Well, you use the `renderExternalView()` method.
+So what if I want to render a view outside of my application without using the setting explained above? Well, you use the `externalView()` method.
 
 ```javascript
-<cfoutput>#renderExternalView(view='/myViewsMapping/tags/footer')#</cfoutput>
+<cfoutput>#externalView(view='/myViewsMapping/tags/footer')#</cfoutput>
 ```
 
+{% hint style="info" %}
+If you are using ColdBox 6.4 or older, you will want to use the `renderExternalView()` method name. In ColdBox 6.5.2+, `renderExternalView()` was deprecated in favor of the new `externalView()` method.
+{% endhint %}


### PR DESCRIPTION
Adds a note for ColdBox 6.5+ and renames the default example to be ColdBox 6.5+ compliant.