### PR TITLE
Fix value pair method name

### DIFF
--- a/the-basics/routing/routing-dsl/routing-by-convention.md
+++ b/the-basics/routing/routing-dsl/routing-by-convention.md
@@ -53,10 +53,10 @@ event=users.show, rc.export=pdf, rc.name={empty value}
 ```
 
 {% hint style="success" %}
-**Tip:** You can turn this feature off by using the `valuePairTranslator( false )` modifier in the routing DSL on a route by route basis
+**Tip:** You can turn this feature off by using the `valuePairTranslation( false )` modifier in the routing DSL on a route by route basis
 
 `route( "/pattern" )  
   .to( "users.show" )  
-  .valuePairTranslator( false );`
+  .valuePairTranslation( false );`
 {% endhint %}
 


### PR DESCRIPTION
Docs incorrectly had the method named `valuePairTranslator()` when it should be `valuePairTranslation()`