### PR TITLE
Drop mention of removed SES interceptor

### DIFF
--- a/getting-started/configuration/coldbox.cfc/configuration-directives/interceptors.md
+++ b/getting-started/configuration/coldbox.cfc/configuration-directives/interceptors.md
@@ -18,8 +18,7 @@ interceptors = [
     { class="mypath.MyInterceptor",
       name="MyInterceptor",
       properties={useSetterInjection=false}
-    },
-    { class="coldbox.system.interceptors.SES", name="MySES" }
+    }
 ];
 ```
 


### PR DESCRIPTION
The Interceptors configuration syntax docs mention the SES interceptor, but this interceptor is removed in ColdBox 6!

https://coldbox.ortusbooks.com/intro/release-history/upgrading-to-coldbox-6#ses-interceptor-removed