### PR TITLE
Fix broken links to Subdomain Routing

### DIFF
--- a/intro/release-history/whats-new-with-6.6.0.md
+++ b/intro/release-history/whats-new-with-6.6.0.md
@@ -43,7 +43,7 @@ There are so many tickets that helped resolved issues with the ColdBox scheduler
 
 ### Integration Testing of Subdomain/Domain Routing
 
-If you are building multi-tenant applications with ColdBox and are leveraging [domain and subdomain routing](whats-new-with-6.6.0.md#undefined), then you can easily use the `domain` argument in all of our `request(), execute()` and HTTP Verb methods to simulate the domain in play for THAT specific spec execution.
+If you are building multi-tenant applications with ColdBox and are leveraging [domain and subdomain routing](https://coldbox.ortusbooks.com/the-basics/routing/routing-dsl/routing-methods#sub-domain-routing), then you can easily use the `domain` argument in all of our `request(), execute()` and HTTP Verb methods to simulate the domain in play for THAT specific spec execution.
 
 ```javascript
 

--- a/testing/testing-coldbox-applications/integration-testing/the-execute-method.md
+++ b/testing/testing-coldbox-applications/integration-testing/the-execute-method.md
@@ -140,7 +140,7 @@ it( "can do a relocation", function() {
 
 ## Subdomain/Domain Routing
 
-If you are building multi-tenant applications with ColdBox and are leveraging [domain and subdomain routing](the-execute-method.md#undefined), then you can easily use the `domain` argument to simulate the domain in play for THAT specific spec execution.
+If you are building multi-tenant applications with ColdBox and are leveraging [domain and subdomain routing](https://coldbox.ortusbooks.com/the-basics/routing/routing-dsl/routing-methods#sub-domain-routing), then you can easily use the `domain` argument to simulate the domain in play for THAT specific spec execution.
 
 ```javascript
 


### PR DESCRIPTION
The link to the Subdomain Routing docs was broken in two places:

* ["What's New With 6.6.0"](https://coldbox.ortusbooks.com/intro/release-history/whats-new-with-6.6.0#integration-testing-of-subdomain-domain-routing)
* ["The Execute Method" in Integration Testing](https://coldbox.ortusbooks.com/testing/testing-coldbox-applications/integration-testing/the-execute-method#subdomain-domain-routing)