### PR TITLE
Update README.md

### DIFF
--- a/the-basics/event-handlers/README.md
+++ b/the-basics/event-handlers/README.md
@@ -83,7 +83,7 @@ function name( event, rc, prc )
 
 Each action receives three arguments:
 
-1. `event` - An object that models and is used to work with the current request
+1. `event` - An object that models and is used to work with the current request (otherwise known as the [Request Context](../request-context.md))
 2. `rc` - A struct that contains both `URL/FORM` variables \(unsafe data\)
 3. `prc` - A secondary struct that is **private**.  This structure is only accessible from within your application \(safe data\)
 


### PR DESCRIPTION
In my brain I always call a requestContext object the 'event'. I always forget that argument 'event' for an action is of type coldbox.system.web.context.RequestContext. 

This is to save other people like me having to google the docs for 30s instead of 2-3 minutes just to read the API docs