### PR TITLE
Fix link to flow diagram

### DIFF
--- a/the-basics/interceptors/core-interception-points/README.md
+++ b/the-basics/interceptors/core-interception-points/README.md
@@ -1,3 +1,3 @@
 # Core Interception Points
 
-There are many interception points that occur during an MVC and Remote life cycle in a ColdBox application. We highly encourage you to follow our flow diagrams in our [ColdBox Overview](broken-reference) section so you can see where in the life cycle these events fire. Also remember that each event can pass a data structure that can be used in your application.
+There are many interception points that occur during an MVC and Remote life cycle in a ColdBox application. We highly encourage you to follow our flow diagrams in our [How ColdBox Works](../../../architecture-concepts/how-coldbox-works#request-lifecycle) section so you can see where in the life cycle these events fire. Also remember that each event can pass a data structure that can be used in your application.


### PR DESCRIPTION
I think this is where it should be pointing: https://coldbox.ortusbooks.com/architecture-concepts/how-coldbox-works#request-lifecycle