### PR TITLE
fix/prePostAdvises: invalid param "action" for pre/post{Action}

### DIFF
--- a/the-basics/event-handlers/interception-methods/post-advices.md
+++ b/the-basics/event-handlers/interception-methods/post-advices.md
@@ -10,7 +10,7 @@ function postHandler( event, rc, prc, action, eventArguments ){
 }
 
 // executes after the list() action ONLY
-function postList( event, rc, prc, action, eventArguments ){
+function postList( event, rc, prc, eventArguments ){
 }
 
 // concrete examples
@@ -22,7 +22,7 @@ function postHandler( event, rc, prc, action, eventArguments ){
 The arguments received by these interceptors are:
 
 * `event` : The request context reference
-* `action` : The action name that was intercepted
+* `action` : The action name that was intercepted by `postHandler()`
 * `eventArguments` : The struct of extra arguments sent to an action if executed via `runEvent()`
 * `rc` : The **RC** reference
 * `prc` : The **PRC** Reference

--- a/the-basics/event-handlers/interception-methods/pre-advices.md
+++ b/the-basics/event-handlers/interception-methods/pre-advices.md
@@ -10,7 +10,7 @@ function preHandler( event, rc, prc, action, eventArguments ){
 }
 
 // executes before the list() action ONLY
-function preList( event, rc, prc, action, eventArguments ){
+function preList( event, rc, prc, eventArguments ){
 }
 
 // concrete example
@@ -20,7 +20,7 @@ function preHandler( event, rc, prc, action, eventArguments ){
         log.info( "Unauthorized accessed detected!", getHTTPRequestData() );
     }
 }
-function preList( event, rc, prc, action, eventArguments ){
+function preList( event, rc, prc, eventArguments ){
     log.info("Starting executing the list action");
 }
 ```
@@ -28,7 +28,7 @@ function preList( event, rc, prc, action, eventArguments ){
 The arguments received by these interceptors are:
 
 * `event` : The request context reference
-* `action` : The action name that was intercepted
+* `action` : The action name that was intercepted by `preHandler()`
 * `eventArguments` : The struct of extra arguments sent to an action if executed via `runEvent()`
 * `rc` : The **RC** reference
 * `prc` : The **PRC** Reference


### PR DESCRIPTION
arguments dump of pre/post{Action}: 
<img width="624" alt="Screenshot 2024-05-03 at 10 01 20" src="https://github.com/ortus-docs/coldbox-docs/assets/108758/891ddb70-a24f-430f-88cf-8edf5cbc04f3">

param `action` only exists in `preHandler()` and `postHandler()`