### PR TITLE
Update event-caching.md

### DIFF
--- a/the-basics/event-handlers/event-caching.md
+++ b/the-basics/event-handlers/event-caching.md
@@ -104,9 +104,7 @@ We have provided an interception point in ColdBox that allows you to add variabl
 ```javascript
 component{
 
-    onRequestCapture(event,interceptData){
-        var rc = event.getCollection();
-
+    onRequestCapture( event, data, buffer, rc, prc ){
         // Add user's locale to the request collection to influence event caching
         rc._user_locale = getFWLocale();
     }


### PR DESCRIPTION
onRequestCapture should work like all interceptors, so we don't have to get rc manually from event