### PR TITLE
docs(routing): AI Gateway routing with toAiGateway()

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -74,6 +74,7 @@
     * [Adding Data to a Route](the-basics/routing/routing-dsl/adding-data-to-a-route.md)
     * [Streaming Routes (SSE)](the-basics/routing/routing-dsl/sse-routes.md)
     * [AI & MCP Routing](the-basics/routing/routing-dsl/ai-routing.md)
+    * [AI Gateway Routing](the-basics/routing/routing-dsl/ai-gateway-routing.md)
   * [Building Routable Links](the-basics/routing/building-routable-links.md)
   * [Advanced Routing Topics](the-basics/routing/advanced-topics.md)
     * [Requirements](the-basics/routing/requirements/README.md)

--- a/digging-deeper/ai/README.md
+++ b/digging-deeper/ai/README.md
@@ -10,7 +10,7 @@ description: >-
 ColdBox 8.x brings first-class artificial intelligence capabilities to the platform thanks to [BoxLang](https://www.boxlang.io/) and [BoxLang AI](https://ai.boxlang.io), organized around four complementary pillars:
 
 1. **BoxLang AI (`bx-ai`)** — a unified fluent SDK for every major LLM provider, supporting chat, streaming, RAG pipelines, tool calling, vector memory, and autonomous agents: https://ai.boxlang.io
-2. **AI Routing** — first-class Router terminators (`toAi()`, `toMCP()`) that auto-generate standard HTTP endpoints for any AI runnable or MCP server, no boilerplate required
+2. **AI Routing** — first-class Router terminators (`toAi()`, `toMCP()`, `toAiGateway()`) that auto-generate standard HTTP endpoints for any AI runnable, MCP server, or AI gateway, no boilerplate required
 3. **ColdBox MCP Server (`cbMCP`)** — a ColdBox module that exposes your running application as a live MCP server, giving any AI client (Claude, Copilot, Cursor) real-time introspection into routing, handlers, WireBox, CacheBox, LogBox, schedulers, and more
 4. **Agentic ColdBox CLI** — AI guidelines, skills, agents, and MCP servers baked into `coldbox-cli` so your AI coding assistant always knows the ColdBox ecosystem
 
@@ -371,6 +371,7 @@ curl -X POST https://myapp.com/agents/support/stream \
 | ------- | :-----: | :--: |
 | `toAi()` routing terminator | ✅ | ❌ |
 | `toMCP()` routing terminator | ✅ | ❌ |
+| `toAiGateway()` routing terminator | ✅ | ❌ |
 | `bx-ai` LLM SDK | ✅ | ❌ |
 | `cbMCP` live MCP server | ✅ | ❌ |
 | Agentic CLI guidelines / skills | ✅ | ✅ |
@@ -386,3 +387,4 @@ curl -X POST https://myapp.com/agents/support/stream \
 | [Agentic ColdBox](agentic-coldbox.md) | AI features in `coldbox-cli` — guidelines, skills, agents, and MCP servers |
 | [ColdBox MCP Server](coldbox-mcp-server.md) | `cbMCP` module — live MCP server exposing 50+ introspection tools for your running app |
 | [AI Routing](../../the-basics/routing/routing-dsl/ai-routing.md) | `toAi()` and `toMCP()` router terminators — full reference |
+| [AI Gateway Routing](../../the-basics/routing/routing-dsl/ai-gateway-routing.md) | `toAiGateway()` — platform webhooks, verification handshakes, and human-in-the-loop approvals |

--- a/readme/release-history/whats-new-with-8.2.0.md
+++ b/readme/release-history/whats-new-with-8.2.0.md
@@ -97,6 +97,29 @@ See [Server-Sent Events](../../the-basics/event-handlers/server-sent-events.md) 
 
 This release also corrects the `toAi()` reference documentation, which had drifted from the actual `run()`/`stream()`-based `IAiRunnable` interface and request/response shapes. See [AI Routing](../../the-basics/routing/routing-dsl/ai-routing.md).
 
+### 🚪 AI Gateway Routing — `toAiGateway()`
+
+A third AI terminator joins `toAi()` and `toMCP()`, covering the direction they don't: a platform talking to *your* agent, on the platform's terms. One declaration mounts everything a [BoxLang AI Gateway](https://ai.ortusbooks.com/) needs over HTTP.
+
+```javascript
+route( "/gateways" ).withSSL().toAiGateway( session: "SupportAgentSession" );
+```
+
+| Verb        | Pattern                                       | Purpose                                     |
+| ----------- | --------------------------------------------- | ------------------------------------------- |
+| `POST`      | `{pattern}[/:gateway]/events`                 | An inbound platform event                   |
+| `GET`       | `{pattern}[/:gateway]/events`                 | The platform's URL verification handshake   |
+| `GET`       | `{pattern}/interactions/:requestID`           | Poll a pending human-in-the-loop approval   |
+| `POST`      | `{pattern}/interactions/:requestID/decisions` | Submit a human's decision                   |
+| `GET`       | `{pattern}/info`                              | What this mount serves                      |
+
+* `GET` and `POST` share `/events` on purpose: a platform is given **one** URL and verifies it with a `GET` before it will `POST` to it.
+* Pin a mount with `toAiGateway( "slack" )`, or leave the name out and one mount serves every gateway registered in `aiGatewayRegistry()`. A pinned name always wins over the URL placeholder.
+* Pass a `session` and every inbound message is dispatched as an agent turn and acked `202` **immediately**, without waiting on the turn - a platform webhook times out in seconds, an agent turn does not. The thread each message landed on comes back in the response (and as `X-Thread-Id`) so you can correlate the reply. Without a session, events are verified and parsed only.
+* Signatures are verified by the gateway itself before anything is parsed or dispatched.
+
+BoxLang + `bx-ai` only. See [AI Gateway Routing](../../the-basics/routing/routing-dsl/ai-gateway-routing.md).
+
 ### 🔒 Hardened HTTP Method Spoofing
 
 The `_method` form-field override (`GET`/`POST` browsers use to fake `PUT`/`PATCH`/`DELETE`) is now only honored when the *original* transport-level request is a `POST`. Previously, a plain `GET` request carrying `?_method=DELETE` was silently treated as a `DELETE` — enabling CSRF-style attacks via a link, an `<img>` tag, a crawler, or a browser prefetch. A new `event.getOriginalHTTPMethod()` returns the raw, un-spoofed verb when you need it. See [HTTP Method Spoofing](../../the-basics/routing/http-method-spoofing.md).
@@ -120,6 +143,8 @@ The `_method` form-field override (`GET`/`POST` browsers use to fake `PUT`/`PATC
 [COLDBOX-1417](https://ortussolutions.atlassian.net/browse/COLDBOX-1417) Conversational context (userId/conversationId/threadId) on `toAi()` routes
 
 First-class Server-Sent Events streaming - `event.sse()`, `SSEEmitter`, `Router.toSSE()`, interception points, `this.sse` settings ([#676](https://github.com/ColdBox/coldbox-platform/pull/676))
+
+AI Gateway routing - `Router.toAiGateway()` mounts a BoxLang AI Gateway's inbound events, verification handshake, and human-in-the-loop approval endpoints ([#694](https://github.com/ColdBox/coldbox-platform/pull/694))
 
 ### Improvements
 

--- a/the-basics/routing/routing-dsl/README.md
+++ b/the-basics/routing/routing-dsl/README.md
@@ -74,4 +74,5 @@ Terminators finalize the routing process by registering the route in the Router.
 * `toNamespaceRouting( namespace )` - Send to the namespace router for evaluation
 * `toAi( target, [name] )` - Register four AI inference routes (invoke, stream, batch, info) for an `IAiRunnable` target. **BoxLang + bx-ai only.**
 * `toMCP( [name] )` - Register a Model Context Protocol (MCP) server endpoint. **BoxLang + bx-ai only.**
+* `toAiGateway( [gateway], [session] )` - Expose a [BoxLang AI Gateway](ai-gateway-routing.md) over HTTP: inbound platform events, URL verification handshakes, and human-in-the-loop approvals. **BoxLang + bx-ai only.**
 * `toSSE( callback )` - Terminate the route with a [Server-Sent Events stream](sse-routes.md). **BoxLang only.**

--- a/the-basics/routing/routing-dsl/ai-gateway-routing.md
+++ b/the-basics/routing/routing-dsl/ai-gateway-routing.md
@@ -1,0 +1,215 @@
+---
+description: >-
+  Expose a BoxLang AI Gateway over HTTP with toAiGateway() - inbound platform
+  events, URL verification handshakes, and human-in-the-loop approvals.
+---
+
+# AI Gateway Routing
+
+{% hint style="warning" %}
+AI Gateway Routing requires **BoxLang** and the **bx-ai** module. It is not available on CFML engines.
+{% endhint %}
+
+A **gateway** (bx-ai's `IGateway`) is a bidirectional adapter between an agent and a platform: Slack, Telegram, WhatsApp, a signed webhook of your own. It turns a platform's inbound payload into a normalized message, and turns the agent's output back into something that platform understands.
+
+`toAiGateway()` puts that surface on a route. One declaration registers everything a platform needs to talk to your application:
+
+```javascript
+route( "/gateways" ).toAiGateway( session: "SupportAgentSession" );
+```
+
+Like `resources()`, `toAi()` and `toMCP()`, a single declaration expands into several concrete routes, and every modifier already on the route (`.withSSL()`, `.withDomain()`, `.withCondition()`, `.as()`, `.withModule()`) is inherited by all of them.
+
+## The Routes It Registers
+
+| HTTP Verb   | Pattern                                        | Purpose                                          |
+| ----------- | ---------------------------------------------- | ------------------------------------------------ |
+| `POST`      | `{pattern}[/:gateway]/events`                  | An inbound platform event                        |
+| `GET`       | `{pattern}[/:gateway]/events`                  | The platform's URL verification handshake        |
+| `GET`       | `{pattern}/interactions/:requestID`            | Poll a pending human-in-the-loop interaction     |
+| `POST`      | `{pattern}/interactions/:requestID/decisions`  | Submit a human's decision                        |
+| `GET`       | `{pattern}/info`                               | What this mount serves                           |
+
+`GET` and `POST` deliberately share the `/events` path. A platform is given **one** URL to store, and most verify it with a `GET` before they will ever `POST` anything to it - Meta's `hub.challenge` echo being the canonical example. One URL, both roles.
+
+Route names follow the base route's name (or its pattern): `{base}.gateway.events`, `{base}.gateway.interaction`, `{base}.gateway.decision`, `{base}.gateway.info`.
+
+## Arguments
+
+```javascript
+route( pattern ).toAiGateway( [ gateway ], [ session ] )
+```
+
+| Argument  | Type             | Description                                                                                                                |
+| --------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `gateway` | string           | The registered gateway name to pin this mount to. Defaults to empty, which mounts a `:gateway` placeholder serving every gateway in `aiGatewayRegistry()` |
+| `session` | string or object | A WireBox ID (resolved on every request) or a live `GatewaySession`. Defaults to empty, which parses inbound events without dispatching them |
+
+## One Mount, Every Gateway
+
+Leave the gateway name out and the terminator inserts its own `:gateway` placeholder, so a single mount serves everything registered in `aiGatewayRegistry()`:
+
+```javascript
+// config/Router.bx
+function configure(){
+
+    route( "/gateways" )
+        .withSSL()
+        .toAiGateway( session: "SupportAgentSession" );
+
+}
+```
+
+```
+POST /gateways/slack/events      → the "slack" gateway
+POST /gateways/telegram/events   → the "telegram" gateway
+GET  /gateways/info              → every registered gateway and its capabilities
+```
+
+## Pinned To One Gateway
+
+Pass a name and the mount is fixed to that gateway, with no placeholder in the URL:
+
+```javascript
+route( "/webhooks/slack" ).toAiGateway( "slack", "SupportAgentSession" );
+```
+
+```
+POST /webhooks/slack/events
+GET  /webhooks/slack/events
+```
+
+A pinned name always wins over anything in the request collection, so a request can never redirect a pinned mount at a different gateway.
+
+## Dispatching To An Agent
+
+Pass a `session` and every message parsed out of an inbound event is dispatched as an agent turn, and the request is acked **`202` immediately** - the turn is never waited on. This is deliberate: a platform webhook times out in seconds, while an agent turn takes as long as it takes.
+
+```json
+{
+    "accepted" : 1,
+    "messages" : [ { "id" : "...", "threadId" : "slack:C1234" } ]
+}
+```
+
+The thread each message landed on comes back in the body, and single-message events also echo it as an `X-Thread-Id` response header - so you can correlate the reply that the gateway delivers later.
+
+Omit the `session` and nothing is dispatched: the event is verified, parsed, and returned as `200` with the normalized messages, for your own code to handle.
+
+```javascript
+// Verify and parse only - no agent is called
+route( "/gateways" ).toAiGateway();
+```
+
+## Wiring The Session
+
+The `session` argument is a WireBox ID resolved on every request, so registering the route never forces the session to be constructed. Build it in a factory model and map it as a singleton:
+
+```javascript
+// models/GatewaySessionFactory.bx
+class {
+
+    property name="supportAgent" inject="SupportAgent";
+
+    function build(){
+        return aiGatewaySession(
+            agent   : variables.supportAgent,
+            gateways: [ aiGatewayRegistry().get( "slack" ) ],
+            policy  : "queue"
+        ).start();
+    }
+
+}
+```
+
+```javascript
+// config/WireBox.bx
+function configure(){
+
+    map( "SupportAgentSession" )
+        .toFactoryMethod( factory: "GatewaySessionFactory", method: "build" )
+        .asSingleton();
+
+}
+```
+
+The gateways themselves are registered with bx-ai at startup, not by ColdBox - a module's `onLoad()` or an `afterAspectsLoad()` interceptor is a good home:
+
+```javascript
+aiGatewayRegistry().register(
+    aiGateway( "http", { secret: getSystemSetting( "GATEWAY_SECRET" ) } )
+);
+```
+
+A live session object works too, if you already have one:
+
+```javascript
+route( "/gateways" ).toAiGateway( session: application.supportSession );
+```
+
+## Security
+
+Every inbound event is handed to the gateway's own `verifyInbound()` **before** it is parsed or dispatched, and a decision submission is verified against the gateway's signing scheme. Each gateway owns its scheme - bx-ai's `http` gateway uses HMAC-SHA256 with nonce dedup and a timestamp tolerance; a platform gateway uses whatever that platform sends.
+
+| Status | Meaning                                                         |
+| ------ | ---------------------------------------------------------------- |
+| `202`  | Accepted and dispatched                                          |
+| `200`  | Verified and parsed (no session), or an interaction read/decided |
+| `400`  | The body was not valid JSON                                      |
+| `401`  | Signature verification failed                                    |
+| `404`  | Unknown gateway, or unknown interaction                          |
+| `405`  | The gateway does not support a verification handshake            |
+| `409`  | That interaction was already resolved                            |
+| `410`  | That interaction expired                                         |
+
+Since these endpoints are internet-facing by definition, pair them with `.withSSL()`, and keep secrets in environment variables rather than in your Router.
+
+## Human-In-The-Loop
+
+When an agent suspends for human approval, the interaction endpoints are how a human answers it:
+
+```
+GET  /gateways/interactions/{requestID}            → the pending question and its allowed decisions
+POST /gateways/interactions/{requestID}/decisions  → { "decision": "approve", "reason": "looks fine" }
+```
+
+The decision request must be signed the same way an inbound event is. Both endpoints live under the mount's base path, not under a gateway name: an interaction is resolved by its id across every registered gateway.
+
+## Modifier Inheritance
+
+```javascript
+route( "/gateways" )
+    .withSSL()
+    .withDomain( "hooks.myapp.com" )
+    .withCondition( ( route, params, event ) => !maintenanceMode )
+    .toAiGateway( session: "SupportAgentSession" );
+```
+
+Every generated sub-route carries all three.
+
+## Choosing A Terminator
+
+| Terminator      | Use it for                                                                           |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `toAi()`        | Your own HTTP API in front of an agent - you control the client                       |
+| `toMCP()`       | Exposing tools and data to MCP clients over the Model Context Protocol                |
+| `toAiGateway()` | A platform talking to your agent on the platform's terms - webhooks, signatures, HITL |
+
+They compose freely:
+
+```javascript
+// config/Router.bx
+function configure(){
+
+    route( "/api/chat" ).withSSL().toAi( "models.ChatAgent" );
+    route( "/mcp/:mcpServer" ).withSSL().toMCP();
+    route( "/gateways" ).withSSL().toAiGateway( session: "SupportAgentSession" );
+
+}
+```
+
+## Learn More
+
+* [AI & MCP Routing](ai-routing.md) - the `toAi()` and `toMCP()` terminators
+* [Agentic ColdBox](../../../digging-deeper/ai/agentic-coldbox.md) - building agents in a ColdBox app
+* [BoxLang AI documentation](https://ai.ortusbooks.com/) - gateways, sessions, and the `IGateway` interface

--- a/the-basics/routing/routing-dsl/ai-routing.md
+++ b/the-basics/routing/routing-dsl/ai-routing.md
@@ -15,6 +15,8 @@ ColdBox 8.1 introduces two powerful routing terminators for building AI-powered 
 * `toAi()` — Registers four standard AI inference endpoints (invoke, stream, batch, info) for any `IAiRunnable` object
 * `toMCP()` — Registers a Model Context Protocol (MCP) server endpoint handled by `MCPRequestProcessor`
 
+A third terminator, [`toAiGateway()`](ai-gateway-routing.md), covers the other direction: a platform (Slack, Telegram, WhatsApp, a signed webhook) talking to your agent on its own terms, signatures and human approvals included.
+
 Both terminators behave like the `resources()` terminator: a single declaration expands to multiple concrete routes and all shared route **modifiers** (`.as()`, `.withModule()`, `.withDomain()`, etc.) are inherited by every generated sub-route.
 
 ---

--- a/the-basics/routing/routing-dsl/routing-methods.md
+++ b/the-basics/routing/routing-dsl/routing-methods.md
@@ -14,5 +14,6 @@ This page used to hold every route terminator in one long document. It's now spl
 | [Adding Data to a Route](adding-data-to-a-route.md) | `rc()`, `prc()`, `rcAppend()`, `prcAppend()` |
 | [Streaming Routes (SSE)](sse-routes.md)        | `toSSE()`                                         |
 | [AI & MCP Routing](ai-routing.md)              | `toAi()`, `toMCP()`                               |
+| [AI Gateway Routing](ai-gateway-routing.md)    | `toAiGateway()`                                   |
 
 See the [Routing DSL overview](README.md) for the full method reference across initiators, modifiers, and terminators.


### PR DESCRIPTION
Documents the new `toAiGateway()` routing terminator added in ColdBox/coldbox-platform#694, which mounts a BoxLang AI Gateway over HTTP alongside `toAi()` and `toMCP()`.

**New page:** `the-basics/routing/routing-dsl/ai-gateway-routing.md`

Covers the routes it registers, why `GET` and `POST` share the `/events` path (a platform is given one URL and verifies it with a `GET` first), pinned versus `:gateway` placeholder mounts, dispatching into a `GatewaySession` versus parse-only, the `202`-without-waiting semantics and thread correlation, wiring the session through WireBox and registering gateways with `aiGatewayRegistry()`, the status code each failure path returns, the human-in-the-loop interaction endpoints, and a short table for choosing between the three AI terminators.

**Cross-links updated**

- `SUMMARY.md` — new entry under Routing DSL, after AI & MCP Routing
- `the-basics/routing/routing-dsl/README.md` — terminator list
- `the-basics/routing/routing-dsl/routing-methods.md` — methods table
- `the-basics/routing/routing-dsl/ai-routing.md` — pointer to the third terminator
- `digging-deeper/ai/README.md` — AI Routing pillar, feature coverage matrix, sections table
- `readme/release-history/whats-new-with-8.2.0.md` — highlight section plus a New Features line

Code samples use only APIs verified against the ColdBox and bx-ai sources: `toFactoryMethod( factory, method )` / `asSingleton()` on the WireBox binder, and `aiGatewaySession()` / `aiGatewayRegistry()` / `aiGateway()` from bx-ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRppywTeuVpXgVG24Wm9W

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRppywTeuVpXgVG24Wm9W)_