### PR TITLE
docs: finalize ColdBox 8.2.0 What's New and add Route-Level Caching page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -72,6 +72,7 @@
     * [Routing Conditions](the-basics/routing/routing-dsl/routing-conditions.md)
     * [Routing Namespaces](the-basics/routing/routing-dsl/routing-namespaces.md)
     * [Adding Data to a Route](the-basics/routing/routing-dsl/adding-data-to-a-route.md)
+    * [Route-Level Caching](the-basics/routing/routing-dsl/route-caching.md)
     * [Streaming Routes (SSE)](the-basics/routing/routing-dsl/sse-routes.md)
     * [AI & MCP Routing](the-basics/routing/routing-dsl/ai-routing.md)
     * [AI Gateway Routing](the-basics/routing/routing-dsl/ai-gateway-routing.md)

--- a/readme/release-history/whats-new-with-8.2.0.md
+++ b/readme/release-history/whats-new-with-8.2.0.md
@@ -124,6 +124,38 @@ BoxLang + `bx-ai` only. See [AI Gateway Routing](../../the-basics/routing/routin
 
 The `_method` form-field override (`GET`/`POST` browsers use to fake `PUT`/`PATCH`/`DELETE`) is now only honored when the *original* transport-level request is a `POST`. Previously, a plain `GET` request carrying `?_method=DELETE` was silently treated as a `DELETE` — enabling CSRF-style attacks via a link, an `<img>` tag, a crawler, or a browser prefetch. A new `event.getOriginalHTTPMethod()` returns the raw, un-spoofed verb when you need it. See [HTTP Method Spoofing](../../the-basics/routing/http-method-spoofing.md).
 
+### 🗄️ Route-Level Cache Rules — `Router.withCache()`
+
+A route-scoped alternative to handler `cache="true"` annotations, so caching can be declared where the URL is declared instead of buried on the handler action. `.withCache()` accepts the same knobs as the handler annotations — timeout, provider, suffix, include/exclude/filter — plus the Tier 1 HTTP caching primitives (`etag`, `etagWeak`, `lastModified`, `cacheControl`). A route that opts in takes full precedence over that event's handler-level cache annotations; routes that don't opt in fall through unchanged.
+
+```javascript
+route( "/products/:id" )
+    .withCache( timeout : 30, etag : true )
+    .toHandler( "products.show" );
+```
+
+See [Router.withCache()](../../the-basics/routing/routing-dsl/route-caching.md).
+
+### ⏰ Scheduler Timing Fixes
+
+Two related scheduler bugs are fixed:
+
+* A task combining `every()` with `startOnTime()`/`between()` now waits for the next aligned period boundary instead of firing immediately on registration (or every server/container restart).
+* A task combining `withNoOverlaps()` with `between()`/`startOnTime()` no longer misreads its `spacedDelay` unit — a `1`-minute task no longer re-fires every second.
+
+{% hint style="warning" %}
+The first fix is a behavior change for anyone currently relying on the old "fire immediately at registration" semantics for `every()` + `startOnTime()`/`between()`.
+{% endhint %}
+
+### 🌐 Full BoxLang Null-Runtime Support
+
+ColdBox now runs cleanly under BoxLang with `enableNullSupport` enabled, closing out the framework-wide gaps in null handling this setting exposes.
+
+### 🧭 Routing & Annotation Fixes
+
+* Fluent routes now correctly preserve their domain when grouped or resolved through nested routes.
+* Handler metadata annotations nested under other annotations are now read correctly on BoxLang.
+
 ### ⚡ Renderer & Routing Performance
 
 * A new `viewDiscoveryCaching` setting (on by default, independent of `viewCaching`) caches the filesystem work that locates view/layout files, benefiting every render regardless of whether view *output* caching is enabled. See [View Discovery Caching](../../the-basics/layouts-and-views/views/view-caching.md#view-discovery-caching).
@@ -144,7 +176,9 @@ The `_method` form-field override (`GET`/`POST` browsers use to fake `PUT`/`PATC
 
 First-class Server-Sent Events streaming - `event.sse()`, `SSEEmitter`, `Router.toSSE()`, interception points, `this.sse` settings ([#676](https://github.com/ColdBox/coldbox-platform/pull/676))
 
-AI Gateway routing - `Router.toAiGateway()` mounts a BoxLang AI Gateway's inbound events, verification handshake, and human-in-the-loop approval endpoints ([#694](https://github.com/ColdBox/coldbox-platform/pull/694))
+AI Gateway routing - `Router.toAiGateway()` mounts a BoxLang AI Gateway's inbound events, verification handshake, and human-in-the-loop approval endpoints ([COLDBOX-1435](https://ortussolutions.atlassian.net/browse/COLDBOX-1435), [#694](https://github.com/ColdBox/coldbox-platform/pull/694))
+
+[COLDBOX-1418](https://ortussolutions.atlassian.net/browse/COLDBOX-1418) Route-level cache rules via `Router.withCache()`
 
 ### Improvements
 
@@ -154,7 +188,9 @@ New `viewDiscoveryCaching` setting plus Renderer hot-path caching for view/layou
 
 Hot-path performance optimizations in `HandlerService`, `RoutingService`, and `Router` ([#665](https://github.com/ColdBox/coldbox-platform/pull/665))
 
-Interceptor chain now reports and honors short-circuiting via `announce()`'s return value; new `getRouteDefinitionKeys()` route-table introspection helper ([#677](https://github.com/ColdBox/coldbox-platform/pull/677))
+[COLDBOX-1447](https://ortussolutions.atlassian.net/browse/COLDBOX-1447) Interceptor chain now reports and honors short-circuiting via `announce()`'s return value; new `getRouteDefinitionKeys()` route-table introspection helper ([#677](https://github.com/ColdBox/coldbox-platform/pull/677))
+
+[COLDBOX-1440](https://ortussolutions.atlassian.net/browse/COLDBOX-1440) Full BoxLang null-runtime support (`enableNullSupport`)
 
 ### Bugs
 
@@ -162,8 +198,42 @@ Interceptor chain now reports and honors short-circuiting via `announce()`'s ret
 
 [COLDBOX-1411](https://ortussolutions.atlassian.net/browse/COLDBOX-1411) `this.EVENT_CACHE_SUFFIX` closures were evaluated once and frozen instead of per-request, letting different requests share a cache key
 
-`DataMarshaller` component made thread-safe ([#672](https://github.com/ColdBox/coldbox-platform/pull/672))
+[COLDBOX-1421](https://ortussolutions.atlassian.net/browse/COLDBOX-1421) Scheduled tasks using `every()` + `startOnTime()`/`between()` fired immediately instead of aligning to the next period boundary
+
+[COLDBOX-1434](https://ortussolutions.atlassian.net/browse/COLDBOX-1434) `ScheduledTask` combining `withNoOverlaps()` with a daily start time misread the `spacedDelay` unit, causing rapid re-fire
+
+[COLDBOX-1438](https://ortussolutions.atlassian.net/browse/COLDBOX-1438) Fluent route domain grouping/nesting not preserved
+
+[COLDBOX-1439](https://ortussolutions.atlassian.net/browse/COLDBOX-1439) Nested handler annotations not read correctly
+
+[COLDBOX-1446](https://ortussolutions.atlassian.net/browse/COLDBOX-1446) `addRoute()` missing `ai`/`aiRunnable`/`mcp`/`mcpServer` parameters
+
+[COLDBOX-1448](https://ortussolutions.atlassian.net/browse/COLDBOX-1448) `DataMarshaller` component made thread-safe
+
+[COLDBOX-1449](https://ortussolutions.atlassian.net/browse/COLDBOX-1449) `appHash` property missing default value
 
 Fixed a startup typo in `Bootstrap.cfc` ([#667](https://github.com/ColdBox/coldbox-platform/pull/667))
+
+### Tasks
+
+[COLDBOX-1450](https://ortussolutions.atlassian.net/browse/COLDBOX-1450) Deprecation markers for legacy tools and Adobe 2023 static scope ahead of v9
+{% endtab %}
+
+{% tab title="WireBox" %}
+### Bugs
+
+[COLDBOX-1420](https://ortussolutions.atlassian.net/browse/COLDBOX-1420) Explicit WireBox mapping was deleted when its first metadata lookup failed
+{% endtab %}
+
+{% tab title="CacheBox" %}
+### Bugs
+
+[COLDBOX-1422](https://ortussolutions.atlassian.net/browse/COLDBOX-1422) `BoxLangProvider` did not convert CacheBox's minute-based timeouts, causing objects to expire 60x too soon
+{% endtab %}
+
+{% tab title="LogBox" %}
+### Bugs
+
+[COLDBOX-1400](https://ortussolutions.atlassian.net/browse/COLDBOX-1400) Root appender could be called before LogBox finished initializing during loading
 {% endtab %}
 {% endtabs %}

--- a/the-basics/routing/routing-dsl/route-caching.md
+++ b/the-basics/routing/routing-dsl/route-caching.md
@@ -1,0 +1,69 @@
+---
+description: >-
+  Declare event caching and HTTP caching rules on a route instead of on the
+  handler action.
+---
+
+# Route-Level Caching
+
+`.withCache()` is a route-scoped alternative to handler `cache="true"` annotations, so caching can be declared where the URL is declared instead of buried on the handler action.
+
+```javascript
+route( "/products/:id" )
+    .withCache( timeout : 30 )
+    .toHandler( "products.show" );
+```
+
+## Arguments
+
+`.withCache()` mirrors every existing handler-level cache annotation one-for-one, plus the [HTTP caching](../../../digging-deeper/http-caching.md) primitives:
+
+| Argument                  | Mirrors handler annotation | Description                                    |
+| -------------------------- | --------------------------- | ----------------------------------------------- |
+| `cache`                    | `cache`                      | Boolean toggle, defaults to `true` when called |
+| `cacheTimeout`              | `cacheTimeout`                | Minutes before the entry expires                |
+| `cacheLastAccessTimeout`    | `cacheLastAccessTimeout`      | Idle-eviction timeout, in minutes               |
+| `cacheProvider`             | `cacheProvider`                | Named CacheBox provider to store the entry in   |
+| `cacheSuffix`               | `EVENT_CACHE_SUFFIX`           | A static string, or `function( event )`         |
+| `cacheInclude`              | `cacheInclude`                 | RC keys to fold into the cache key hash         |
+| `cacheExclude`              | `cacheExclude`                 | RC keys to leave out of the hash                |
+| `cacheFilter`               | `cacheFilter`                  | A closure deciding whether to cache this request |
+| `etag` / `etagWeak`         | n/a                             | Auto-computed `ETag` on a cache hit or store     |
+| `lastModified`              | n/a                             | Auto-computed `Last-Modified` on a cache hit or store |
+| `cacheControl`              | n/a                             | A `Cache-Control` directives struct              |
+
+{% hint style="info" %}
+`cacheSuffix` closures use the signature `function( event )`, distinct from the handler-level `EVENT_CACHE_SUFFIX`'s `function( eventHandlerBean, event )` - a route has no reflected handler-action metadata to hand it.
+{% endhint %}
+
+## Precedence
+
+A route that calls `.withCache()` takes full precedence over that same event's handler-level cache annotations, for any request matching it. Routes that don't opt in fall through unchanged to the existing handler-annotation path - zero behavior change for apps that don't use it.
+
+This means two different routes pointing at the same event can carry two different cache policies - something a handler annotation, keyed by event name alone, could never do:
+
+```javascript
+// Public catalog view: cache aggressively
+route( "/catalog/:id" )
+    .withCache( timeout : 60 )
+    .toHandler( "products.show" );
+
+// Admin preview of the same handler: never cache
+route( "/admin/preview/:id" ).toHandler( "products.show" );
+```
+
+## Combining With HTTP Caching
+
+`etag`, `etagWeak`, `lastModified`, and `cacheControl` piggyback on the same event-caching lookup, so a cached route can answer a conditional `GET` with a `304 Not Modified` before the handler ever runs again:
+
+```javascript
+route( "/products/:id" )
+    .withCache( timeout : 30, etag : true, cacheControl : { "max-age" : 60 } )
+    .toHandler( "products.show" );
+```
+
+See [HTTP Caching](../../../digging-deeper/http-caching.md) for the underlying `event.etag()`/`event.cacheControl()` primitives this builds on.
+
+{% hint style="success" %}
+**Next:** the underlying ETag/Last-Modified/Cache-Control primitives you can also call directly from a handler - see [HTTP Caching](../../../digging-deeper/http-caching.md).
+{% endhint %}


### PR DESCRIPTION
## Summary
- Fills in real content gaps found in `whats-new-with-8.2.0.md` during a full audit of the 8.2 Jira ticket list against the doc: `Router.withCache()`, the two scheduler timing fixes (COLDBOX-1421, COLDBOX-1434), full BoxLang null-runtime support, and the fluent-route/handler-annotation fixes.
- Splits the Release Notes into WireBox/CacheBox/LogBox tabs (their few 8.2 fixes ship bundled under the ColdBox version, but weren't previously called out).
- Corrects several ticket-number references in the Release Notes to match the actual Jira issues.
- Adds the missing `the-basics/routing/routing-dsl/route-caching.md` page for `Router.withCache()` — it was already linked from the What's New page but had never been written.

## Test plan
- [ ] Visually review the rendered What's New page and new Route-Level Caching page on GitBook preview
- [ ] Confirm all COLDBOX-XXXX links resolve to the intended Jira issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7vyEDCVLA9nFp6NrsajWL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7vyEDCVLA9nFp6NrsajWL)_